### PR TITLE
Fix running commands with quotes

### DIFF
--- a/xfce-do-release
+++ b/xfce-do-release
@@ -65,7 +65,7 @@ run_command () {
 	read -n 1 -p " → Do it? (yes/skip/abort)" response
 	printf "\n"
 	if [ "$response" = "y" ]; then
-		$1 && $2 && $3
+		eval $1 && eval $2 && eval $3
 		printf "\n ✓ Done."
 		let steps_complete++
 	elif [ "$response" = "s" ]; then


### PR DESCRIPTION
I was getting the following error:
```
Step 3: Commit the changes (git add -u; git commit -m 'Updates for release')
 ==================
 → Do it? (yes/skip/abort)y
error: pathspec 'for' did not match any file(s) known to git
error: pathspec 'release'' did not match any file(s) known to git

 ✓ Done.
```

Maybe the script should use `set -e` so it stops on errors?