### PR TITLE
Fix for #14

### DIFF
--- a/xfce-migrate-to-gl
+++ b/xfce-migrate-to-gl
@@ -10,8 +10,10 @@ migrate_to_gl () {
       if git ls-files >& /dev/null; then
           if git remote -v | grep git.xfce.org >& /dev/null; then
               echo "* Updating git remotes in $d"
-              sed -i 's|git.xfce.org|gitlab.xfce.org|g' .git/config
-              sed -i 's|git://|https://|g' .git/config
+              sed -Ei '
+                  s|git://|https://|
+                  s|git\.xfce\.org(.*[^/])/?|gitlab.xfce.org\1.git|
+              ' .git/config
               echo "  ✓ Done"
           fi
       fi


### PR DESCRIPTION
A few more changes from what was said in #14:
* grouping of sed commands in a mini-script;
* removal of unnecessary `g` (unless I am mistaken, there can only be one url per line);
* manage cases with or without final `/`.

With this test file:
```
[remote "origin"]
  url = https://git.xfce.org/xfce/xfce4-session
  url = https://git.xfce.org/xfce/xfce4-session/
  url = git://git.xfce.org/xfce/xfce4-session
  url = git://git.xfce.org/xfce/xfce4-session/
```
we obtain:
```
[remote "origin"]
  url = https://gitlab.xfce.org/xfce/xfce4-session.git
  url = https://gitlab.xfce.org/xfce/xfce4-session.git
  url = https://gitlab.xfce.org/xfce/xfce4-session.git
  url = https://gitlab.xfce.org/xfce/xfce4-session.git
```